### PR TITLE
Use PORT environment variable

### DIFF
--- a/.env.railway
+++ b/.env.railway
@@ -21,7 +21,7 @@ QUICKNODE_API_KEY=your-quicknode-api-key
 GOPLUS_API_KEY=your-goplus-api-key
 
 # Network Configuration
-PORT=5000
+# PORT is automatically set by Railway
 CORS_ORIGINS=*
 
 # Frontend Configuration (Set this to your Railway backend service URL)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Default port configuration
+ARG PORT=5000
+ENV PORT=${PORT}
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \
@@ -25,11 +29,11 @@ USER app
 RUN mkdir -p logs data database
 
 # Expose port
-EXPOSE 5000
+EXPOSE ${PORT}
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:5000/api/trading/status || exit 1
+    CMD curl -f http://localhost:${PORT}/api/trading/status || exit 1
 
 # Start application with gunicorn
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "120", "main:app"]
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT} --workers 4 --timeout 120 main:app"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -62,4 +62,5 @@ app = create_app()
 
 if __name__ == '__main__':
     debug_mode = os.getenv('DEBUG', 'false').lower() == 'true'
-    app.run(host='0.0.0.0', port=5000, debug=debug_mode)
+    port = int(os.getenv('PORT', '5000'))
+    app.run(host='0.0.0.0', port=port, debug=debug_mode)


### PR DESCRIPTION
## Summary
- Make backend port configurable via `PORT` env variable
- Update Flask app to read `PORT` from environment
- Remove hard-coded `PORT` from Railway env file

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'enhanced_trading_system')*

------
https://chatgpt.com/codex/tasks/task_e_68b5d730801483278677eae5c0d8563c