### PR TITLE
Include lucide-react icons in frontend bundle

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,9 +14,6 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: false,
     emptyOutDir: true,
-    rollupOptions: {
-      external: ['lucide-react'], // ✅ добавлено для устранения ошибки импорта
-    },
   },
   server: {
     host: '0.0.0.0',


### PR DESCRIPTION
## Summary
- remove lucide-react from Rollup externals so icon components are bundled

## Testing
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d727bc988327b9f15a63e972b5d0