### PR TITLE
feat: proxy API requests through nginx

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,4 +28,23 @@ server {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
+
+    # Proxy API requests to the backend service
+    location /api/ {
+        proxy_pass http://backend:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Allow cross-origin requests
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type" always;
+
+        # Handle CORS preflight requests
+        if ($request_method = 'OPTIONS') {
+            return 204;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- proxy `/api/` requests from frontend nginx to backend service
- forward standard proxy headers and enable CORS handling

## Testing
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'enhanced_trading_system')*

------
https://chatgpt.com/codex/tasks/task_e_68b5d71a036c8327a35beb1bc725d8da