### PR TITLE
chore: remove runtime VITE_API_URL logic

### DIFF
--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -52,6 +52,8 @@ The Vite configuration has been updated to support Railway deployment. The `allo
    ```
    ⚠️ **Important:** Replace `your-backend-url` with the actual Railway backend URL from step 1.
 
+   `VITE_API_URL` is baked into the frontend during the build. If you need to override the API URL at runtime, inject the value via Nginx or a separate configuration file.
+
 4. **Build and Deploy**
 
 ### 3. Alternative: Single Service Deployment

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ npm install
 npm run dev
 ```
 
+> **Note:** The frontend embeds the API endpoint at build time. Set `VITE_API_URL` in your environment when running `npm run build` or building the Docker image. If you need to change the API URL after build, inject a configuration via Nginx or provide a separate config file.
+
 ## 📊 Trading Features
 
 ### Token Analysis

--- a/frontend/start.sh
+++ b/frontend/start.sh
@@ -3,19 +3,13 @@
 # Railway deployment startup script for frontend
 echo "Starting Railway deployment..."
 
-# If VITE_API_URL is not set, try to detect it from Railway environment
-if [ -z "$VITE_API_URL" ]; then
-    if [ ! -z "$RAILWAY_STATIC_URL" ]; then
-        # Use Railway's backend URL if available
-        export VITE_API_URL="https://$RAILWAY_STATIC_URL"
-        echo "Using Railway URL: $VITE_API_URL"
-    else
-        echo "Warning: VITE_API_URL not set, using default"
-        export VITE_API_URL="http://localhost:5000"
-    fi
+# VITE_API_URL must be supplied at build time.
+# For runtime overrides, inject settings via nginx or a separate config file.
+if [ -n "$VITE_API_URL" ]; then
+    echo "Using VITE_API_URL: $VITE_API_URL"
+else
+    echo "Warning: VITE_API_URL is not set."
 fi
-
-echo "API URL configured as: $VITE_API_URL"
 
 # Start nginx
 echo "Starting nginx..."


### PR DESCRIPTION
## Summary
- remove runtime VITE_API_URL detection in start script
- document that VITE_API_URL must be set during build and runtime overrides should use nginx or config file

## Testing
- `npm test` (fails: Missing script: "test")
- `VITE_API_URL=http://localhost:5000 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d70ca424832780a892c9a7f47836