### PR TITLE
Use API base URL from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ BACKEND_PORT=5000
 FRONTEND_PORT=3000
 CORS_ORIGINS=http://localhost:3000,http://localhost:80
 
+# Frontend Configuration
+VITE_API_URL=http://localhost:5000
+
 # Deployment Configuration
 RAILWAY_STATIC_URL=
 RENDER_EXTERNAL_URL=

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,8 @@ import { Settings } from './components/Settings'
 import { Signals } from './components/Signals'
 import './App.css'
 
+const apiBase = import.meta.env.VITE_API_URL
+
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [systemStatus, setSystemStatus] = useState(null)
@@ -25,7 +27,7 @@ function App() {
 
   const fetchSystemStatus = async () => {
     try {
-      const response = await fetch('/api/trading/status')
+      const response = await fetch(`${apiBase}/api/trading/status`)
       const data = await response.json()
       if (data.success) {
         setSystemStatus(data.data)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,51 +1,58 @@
 // frontend/vite.config.js
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  if (!env.VITE_API_URL) {
+    throw new Error('VITE_API_URL is not defined')
+  }
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+      },
     },
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: false,
-    emptyOutDir: true,
-    rollupOptions: {
-      external: ['lucide-react'], // ✅ добавлено для устранения ошибки импорта
+    build: {
+      outDir: 'dist',
+      sourcemap: false,
+      emptyOutDir: true,
+      rollupOptions: {
+        external: ['lucide-react'], // ✅ добавлено для устранения ошибки импорта
+      },
     },
-  },
-  server: {
-    host: '0.0.0.0',
-    port: 3000,
-    allowedHosts: [
-      '3000-i929sy2oru5yitghw5g3i-6532622b.e2b.dev',
-      'localhost',
-      '127.0.0.1',
-      '.e2b.dev',
-      '.railway.app'  // Added for Railway deployment
-    ],
-    proxy: {
-      '/api': {
-        target: process.env.VITE_API_URL || 'http://localhost:5000',
-        changeOrigin: true,
-        secure: false,
-        configure: (proxy, options) => {
-          // Handle Railway deployment proxy configuration
-          proxy.on('error', (err, req, res) => {
-            console.log('Proxy error:', err);
-          });
-          proxy.on('proxyReq', (proxyReq, req, res) => {
-            console.log('Sending Request to the Target:', req.method, req.url);
-          });
+    server: {
+      host: '0.0.0.0',
+      port: 3000,
+      allowedHosts: [
+        '3000-i929sy2oru5yitghw5g3i-6532622b.e2b.dev',
+        'localhost',
+        '127.0.0.1',
+        '.e2b.dev',
+        '.railway.app'  // Added for Railway deployment
+      ],
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL,
+          changeOrigin: true,
+          secure: false,
+          configure: (proxy, options) => {
+            // Handle Railway deployment proxy configuration
+            proxy.on('error', (err, req, res) => {
+              console.log('Proxy error:', err)
+            })
+            proxy.on('proxyReq', (proxyReq, req, res) => {
+              console.log('Sending Request to the Target:', req.method, req.url)
+            })
+          }
         }
       }
-    }
-  },
-  preview: {
-    port: 3000,
-  },
+    },
+    preview: {
+      port: 3000,
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- read VITE_API_URL at startup and use it for system status fetches
- require VITE_API_URL during Vite builds and proxy setup
- document VITE_API_URL in environment example

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5d6fbb84c832783ba1cf8efc14816